### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/cli/command.dart
+++ b/lib/src/cli/command.dart
@@ -97,6 +97,7 @@ class Init extends Command {
     final file2 = File.fromUri(Uri.parse(to)).openWrite();
     file
         .openRead()
+        .cast<List<int>>()
         .transform(const Utf8Decoder())
         .transform(const LineSplitter())
         .listen((chunk) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: "dartness"
-version: "0.4.1"
+version: "0.4.1+1"
 author: "0xff00ff <0xff00ff@gmail.com>"
 description: "middleware based micro framework for dart. Made for rest api."
 homepage: "https://github.com/0xff00ff/dartness"


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900