### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/bind_test.dart
+++ b/test/bind_test.dart
@@ -31,7 +31,8 @@ void main() {
     final client = new HttpClient();
     final request = await client.getUrl(Uri.parse('http://localhost:4041'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
     print(result);
     expect(result, 'index');
   });
@@ -41,7 +42,8 @@ void main() {
     final request =
         await client.getUrl(Uri.parse('http://localhost:4041/param3'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
     print(result);
     expect(result, 'param3');
   });

--- a/test/dartness_test.dart
+++ b/test/dartness_test.dart
@@ -19,7 +19,8 @@ void main() {
     final client = new HttpClient();
     final request = await client.getUrl(Uri.parse('http://localhost:4041'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect('dartness is working', result);
   });

--- a/test/module_test.dart
+++ b/test/module_test.dart
@@ -25,7 +25,8 @@ void main() {
     final request =
         await client.getUrl(Uri.parse('http://localhost:4042/module'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1r1');
   });
@@ -34,7 +35,8 @@ void main() {
     final client = new HttpClient();
     final request = await client.getUrl(Uri.parse('http://localhost:4042/'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1');
   });

--- a/test/route_test.dart
+++ b/test/route_test.dart
@@ -73,7 +73,8 @@ void main() {
     final client = new HttpClient();
     final request = await client.getUrl(Uri.parse('http://localhost:4042/'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1r1');
   });
@@ -83,7 +84,8 @@ void main() {
     final request =
         await client.getUrl(Uri.parse('http://localhost:4042/fake'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1');
   });
@@ -93,7 +95,8 @@ void main() {
     final request =
         await client.getUrl(Uri.parse('http://localhost:4042/middleware'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1m21r2m22');
   });
@@ -103,7 +106,8 @@ void main() {
     final request = await client
         .getUrl(Uri.parse('http://localhost:4042/middleware/broken'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
 
     expect(result, 'm1m22');
   });
@@ -113,7 +117,8 @@ void main() {
     final request = await client
         .getUrl(Uri.parse('http://localhost:4042/middleware/newer'));
     final response = await request.close();
-    final result = await response.transform(utf8.decoder).join();
+    final result =
+        await response.cast<List<int>>().transform(utf8.decoder).join();
     expect(result, 'm1err');
   });
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900